### PR TITLE
Fix Vercel environment variable names to use underscores

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -11,14 +11,14 @@
     }
   ],
   "env": {
-    "LEAGUE_ID": "@league-id",
-    "ESPN_S2": "@espn-s2",
+    "LEAGUE_ID": "@league_id",
+    "ESPN_S2": "@espn_s2",
     "SWID": "@swid"
   },
   "build": {
     "env": {
-      "LEAGUE_ID": "@league-id",
-      "ESPN_S2": "@espn-s2",
+      "LEAGUE_ID": "@league_id",
+      "ESPN_S2": "@espn_s2",
       "SWID": "@swid"
     }
   }


### PR DESCRIPTION
- Changed @league-id to @league_id
- Changed @espn-s2 to @espn_s2
- Vercel doesn't allow hyphens in secret names

🤖 Generated with [Claude Code](https://claude.ai/code)